### PR TITLE
Avoid corrupting the NgModelController and the FormController when ui-validator returns undefined

### DIFF
--- a/src/validate.js
+++ b/src/validate.js
@@ -65,7 +65,7 @@ angular.module('ui.validate',[])
             // Return as valid for now. Validity is updated when promise resolves.
             return true;
           } else {
-            return expression;
+            return !!expression; // Transform 'undefined' to false (to avoid corrupting the NgModelController and the FormController)
           }
         };
         ctrl.$validators[key] = validateFn;

--- a/test/validateSpec.js
+++ b/test/validateSpec.js
@@ -15,6 +15,10 @@ describe('uiValidate', function () {
     return valueToValidate;
   };
 
+  var undefinedValidator = function () {
+    return undefined;
+  };
+
   beforeEach(module('ui.validate'));
   beforeEach(inject(function ($rootScope, $compile) {
 
@@ -36,7 +40,7 @@ describe('uiValidate', function () {
 
       scope.validate = trueValidator;
       compileAndDigest('<input name="input" ng-model="value" ui-validate="\'validate($value)\'">', scope);
-      expect(scope.form.input.$valid).toBeTruthy();
+      expect(scope.form.input.$valid).toBe(true);
       expect(scope.form.input.$error).toEqual({});
     }));
 
@@ -44,9 +48,19 @@ describe('uiValidate', function () {
 
       scope.validate = falseValidator;
       compileAndDigest('<input name="input" ng-model="value" ui-validate="\'validate($value)\'">', scope);
-      expect(scope.form.input.$valid).toBeFalsy();
+      expect(scope.form.input.$valid).toBe(false);
       expect(scope.form.input.$error).toEqual({ validator: true });
     }));
+
+    it('should not corrupt the NgModelController and the FormController if the validator returns undefined', inject(function () {
+
+      scope.validate = undefinedValidator;
+      compileAndDigest('<input name="input" ng-model="value" ui-validate="\'validate($value)\'">', scope);
+      expect(scope.form.input.$valid).toBe(false);
+      expect(scope.form.$valid).toBe(false);
+      expect(scope.form.input.$error).toEqual({ validator: true });
+    }));
+    
   });
 
   describe('validation on model change', function () {
@@ -56,10 +70,10 @@ describe('uiValidate', function () {
       scope.value = false;
       scope.validate = passedValueValidator;
       compileAndDigest('<input name="input" ng-model="value" ui-validate="\'validate($value)\'">', scope);
-      expect(scope.form.input.$valid).toBeFalsy();
+      expect(scope.form.input.$valid).toBe(false);
 
       scope.$apply('value = true');
-      expect(scope.form.input.$valid).toBeTruthy();
+      expect(scope.form.input.$valid).toBe(true);
     }));
   });
 
@@ -75,12 +89,12 @@ describe('uiValidate', function () {
       scope.value = false;
       scope.validate = passedValueValidator;
       var inputElm = compileAndDigest('<input name="input" ng-model="value" ui-validate="\'validate($value)\'">', scope);
-      expect(scope.form.input.$valid).toBeFalsy();
+      expect(scope.form.input.$valid).toBe(false);
 
       inputElm.val('true');
       inputElm.trigger((sniffer.hasEvent('input') ? 'input' : 'change'));
 
-      expect(scope.form.input.$valid).toBeTruthy();
+      expect(scope.form.input.$valid).toBe(true);
     });
   });
 
@@ -92,9 +106,9 @@ describe('uiValidate', function () {
       scope.validate2 = falseValidator;
 
       compileAndDigest('<input name="input" ng-model="value" ui-validate="{key1 : \'validate1($value)\', key2 : \'validate2($value)\'}">', scope);
-      expect(scope.form.input.$valid).toBeFalsy();
-      expect(scope.form.input.$error.key1).toBeFalsy();
-      expect(scope.form.input.$error.key2).toBeTruthy();
+      expect(scope.form.input.$valid).toBe(false);
+      expect(scope.form.input.$error.key1).toBeUndefined();
+      expect(scope.form.input.$error.key2).toBe(true);
     });
   });
 


### PR DESCRIPTION
It seems angular can't handle validation functions that return 'undefined'. This leads to corruption of the NgModelController and the surrounding FormController. (both end up losing the $valid and $invalid properties)

Returning undefined is a mistake that is easily made in a validator and it doesn't give an obvious error. This pull request makes the validator return false which is more obvious to the user.
