### PR TITLE
Make importable with webpack and es6 import

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,18 @@ Add the specific module to your dependencies:
 angular.module('myApp', ['ui.validate', ...])
 ```
 
+Or using npm, webpack and es6 import
+```sh
+npm install --save angular-ui-validate
+```
+
+Don't add script tags in your html page. instead
+```javascript
+import uiValidate from 'angular-ui-validate'
+
+angular.module('myApp', [uiValidate, ...])
+```
+
 ## Development
 
 We use Karma and jshint to ensure the quality of the code.  The easiest way to run these checks is to use grunt:

--- a/index.js
+++ b/index.js
@@ -1,0 +1,2 @@
+require('./dist/validate');
+module.exports = 'ui.validate';

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "run-sequence": "^1.1.2"
   },
   "scripts": {},
-  "main": "./dist/validate.js",
+  "main": "index.js",
   "repository": {
     "type": "git",
     "url": "https://github.com/angular-ui/ui-validate.git"


### PR DESCRIPTION
This change is required to allow ui-validate to be importable with es6 and bundled with webpack and AngularJS 1.x. Without the change, this is the error that occurs when running the angular app.

```
Uncaught Error: [$injector:modulerr] Failed to instantiate module app due to:
Error: [$injector:modulerr] Failed to instantiate module {} due to:
Error: [ng:areq] Argument 'module' is not a function, got Object
```